### PR TITLE
[fix] 不必要な（_変数名）の（_）を取り除いた。

### DIFF
--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/view/fragment/OneFragment.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/view/fragment/OneFragment.kt
@@ -22,28 +22,28 @@ class OneFragment: Fragment(R.layout.fragment_one){
     {
         super.onViewCreated(view, savedInstanceState)
 
-        val _binding= FragmentOneBinding.bind(view)
+        val binding= FragmentOneBinding.bind(view)
 
-        val _viewModel= OneViewModel(requireContext())
+        val viewModel= OneViewModel(requireContext())
 
-        val _layoutManager= LinearLayoutManager(requireContext())
-        val _dividerItemDecoration=
-            DividerItemDecoration(requireContext(), _layoutManager.orientation)
-        val _adapter= CustomAdapter(object : CustomAdapter.OnItemClickListener{
+        val layoutManager= LinearLayoutManager(requireContext())
+        val dividerItemDecoration=
+            DividerItemDecoration(requireContext(), layoutManager.orientation)
+        val adapter= CustomAdapter(object : CustomAdapter.OnItemClickListener{
             override fun itemClick(item: Item){
                 gotoRepositoryFragment(item)
             }
         })
 
         //EditTextを制御
-        _binding.searchInputText
+        binding.searchInputText
             .setOnEditorActionListener{ editText, action, _ ->
                 //ENTERが押された時の処理
                 if (action== EditorInfo.IME_ACTION_SEARCH){
                     editText.text.toString().let {
                         //submitListに入力された文字を代入
-                        _viewModel.searchResults(it).apply{
-                            _adapter.submitList(this)
+                        viewModel.searchResults(it).apply{
+                            adapter.submitList(this)
                         }
                     }
                     return@setOnEditorActionListener true
@@ -52,18 +52,18 @@ class OneFragment: Fragment(R.layout.fragment_one){
             }
 
         //recyclerViewに代入
-        _binding.recyclerView.also{
-            it.layoutManager= _layoutManager
-            it.addItemDecoration(_dividerItemDecoration)
-            it.adapter= _adapter
+        binding.recyclerView.also{
+            it.layoutManager= layoutManager
+            it.addItemDecoration(dividerItemDecoration)
+            it.adapter= adapter
         }
     }
 
     fun gotoRepositoryFragment(item: Item)
     {
-        val _action= OneFragmentDirections
+        val action= OneFragmentDirections
             .actionRepositoriesFragmentToRepositoryFragment(item= item)
-        findNavController().navigate(_action)
+        findNavController().navigate(action)
     }
 }
 
@@ -94,19 +94,19 @@ class CustomAdapter(
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder
     {
-    	val _view= LayoutInflater.from(parent.context)
+    	val view= LayoutInflater.from(parent.context)
             .inflate(R.layout.layout_item, parent, false)
-    	return ViewHolder(_view)
+    	return ViewHolder(view)
     }
 
     override fun onBindViewHolder(holder: ViewHolder, position: Int)
     {
-    	val _item= getItem(position)
+    	val item= getItem(position)
         (holder.itemView.findViewById<View>(R.id.repositoryNameView) as TextView).text=
-            _item.name
+            item.name
 
     	holder.itemView.setOnClickListener{
-     		itemClickListener.itemClick(_item)
+     		itemClickListener.itemClick(item)
     	}
     }
 }

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/view/fragment/TwoFragment.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/view/fragment/TwoFragment.kt
@@ -28,7 +28,7 @@ class TwoFragment : Fragment(R.layout.fragment_two) {
         binding = FragmentTwoBinding.bind(view)
 
         //OneFragmentから値を受け取る
-        var item = args.item
+        val item = args.item
 
         _binding.ownerIconView.load(item.ownerIconUrl)
         _binding.nameView.text = item.name

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/view/fragment/TwoFragment.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/view/fragment/TwoFragment.kt
@@ -30,12 +30,12 @@ class TwoFragment : Fragment(R.layout.fragment_two) {
         //OneFragmentから値を受け取る
         var item = args.item
 
-        _binding.ownerIconView.load(item.ownerIconUrl);
-        _binding.nameView.text = item.name;
-        _binding.languageView.text = item.language;
-        _binding.starsView.text = "${item.stargazersCount} stars";
-        _binding.watchersView.text = "${item.watchersCount} watchers";
-        _binding.forksView.text = "${item.forksCount} forks";
-        _binding.openIssuesView.text = "${item.openIssuesCount} open issues";
+        _binding.ownerIconView.load(item.ownerIconUrl)
+        _binding.nameView.text = item.name
+        _binding.languageView.text = item.language
+        _binding.starsView.text = "${item.stargazersCount} stars"
+        _binding.watchersView.text = "${item.watchersCount} watchers"
+        _binding.forksView.text = "${item.forksCount} forks"
+        _binding.openIssuesView.text = "${item.openIssuesCount} open issues"
     }
 }


### PR DESCRIPTION
Kotlin公式ドキュメントより

`Names for backing properties﻿
If a class has two properties which are conceptually the same but one is part of a public API and another is an implementation detail, use an underscore as the prefix for the name of the private property:`

これより、getter等で同じ変数名を使う際にのみ、privateを強調するアンダーバーを用いると判断したため、単独で利用されていた（_変数名）の_を削除した。